### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PUNKU.AI Embedded Chat ⛓️
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/PUNKU-AI/punku-embedded-chat)
+
 Welcome to the PUNKU.AI Embedded Chat repository! 🎉
 
 The PUNKU.AI Embedded Chat is a powerful web component that enables seamless communication with the [PUNKU.AI app](https://app.punku.ai). This widget provides a chat interface, allowing you to integrate PUNKU.AI into your web applications effortlessly.


### PR DESCRIPTION
## Summary
Adds a DeepWiki badge to the README for easy access to AI-powered repository exploration.

## Changes
- Added DeepWiki badge at the top of README (right after the title)
- Badge links to https://deepwiki.com/PUNKU-AI/punku-embedded-chat

## Why?
DeepWiki provides users with:
- AI-powered codebase exploration
- Intelligent Q&A about the repository
- Easy access to documentation insights
- Better understanding of the project structure

## Preview
The badge appears as:
[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/PUNKU-AI/punku-embedded-chat)

## Test Plan
- [x] Badge added to README
- [x] Badge link is correct
- [x] Positioned appropriately (top of README)
- [x] Markdown syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)