### PR TITLE
feat: add bottom_offset prop

### DIFF
--- a/src/chatWidget/chatWindow/index.tsx
+++ b/src/chatWidget/chatWindow/index.tsx
@@ -71,7 +71,8 @@ export default function ChatWindow({
   language = 'en' as Language,
   link_color,
   loading_messages,
-  onClose
+  onClose,
+  bottom_offset,
 }: {
   api_key?: string;
   output_type: string,
@@ -124,6 +125,7 @@ export default function ChatWindow({
   language?: Language;
   link_color?: string;
   loading_messages?: string[];
+  bottom_offset?: number;
 }) {
   const HeaderLucideIcon =
     getLucideIconByName(header_icon_name) ?? MessagesSquare;
@@ -387,7 +389,7 @@ export default function ChatWindow({
       }
       style={{
         position: "fixed",
-        bottom: "100px",
+        bottom: `${(bottom_offset ?? 20) + 80}px`,
         right: "20px",
         maxHeight: "70vh",
         maxWidth: "90vw",

--- a/src/chatWidget/index.tsx
+++ b/src/chatWidget/index.tsx
@@ -54,6 +54,7 @@ export default function ChatWidget({
   idle_expiration_hours,
   default_language,
   link_color,
+  bottom_offset,
 }: {
   api_key?: string;
   input_value: string,
@@ -102,6 +103,7 @@ export default function ChatWidget({
   idle_expiration_hours?: number;
   default_language?: string;
   link_color?: string;
+  bottom_offset?: number;
 }) {
   // Initialize session with persistence
   const sessionConfig: SessionConfig = {
@@ -2762,17 +2764,19 @@ input::-ms-input-placeholder { /* Microsoft Edge */
   border-radius: 4px;
 }`
   // Get position styles for the chat trigger based on chat_position prop
+  const effectiveBottomOffset = bottom_offset ?? 20;
+
   const getCornerStyle = (position = "bottom-right") => {
     switch(position) {
       case "top-left":
         return { top: "20px", left: "20px", bottom: "auto", right: "auto" };
-      case "top-right": 
+      case "top-right":
         return { top: "20px", right: "20px", bottom: "auto", left: "auto" };
       case "bottom-left":
-        return { bottom: "20px", left: "20px", top: "auto", right: "auto" };
+        return { bottom: `${effectiveBottomOffset}px`, left: "20px", top: "auto", right: "auto" };
       case "bottom-right":
       default:
-        return { bottom: "20px", right: "20px", top: "auto", left: "auto" };
+        return { bottom: `${effectiveBottomOffset}px`, right: "20px", top: "auto", left: "auto" };
     }
   };
 
@@ -2781,13 +2785,13 @@ input::-ms-input-placeholder { /* Microsoft Edge */
     switch(position) {
       case "top-left":
         return { top: "70px", left: "20px", bottom: "auto", right: "auto" };
-      case "top-right": 
+      case "top-right":
         return { top: "70px", right: "20px", bottom: "auto", left: "auto" };
       case "bottom-left":
-        return { bottom: "70px", left: "20px", top: "auto", right: "auto" };
+        return { bottom: `${effectiveBottomOffset + 50}px`, left: "20px", top: "auto", right: "auto" };
       case "bottom-right":
       default:
-        return { bottom: "70px", right: "20px", top: "auto", left: "auto" };
+        return { bottom: `${effectiveBottomOffset + 50}px`, right: "20px", top: "auto", left: "auto" };
     }
   };
   
@@ -2894,6 +2898,7 @@ input::-ms-input-placeholder { /* Microsoft Edge */
           isRefreshingSession={isRefreshingSession}
           language={currentLanguage}
           link_color={link_color}
+          bottom_offset={effectiveBottomOffset}
         />
       </div>
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,5 +50,6 @@ customElements.define('punku-chat', r2wc(ChatWidget, {
         ttl_hours: "number",
         idle_expiration_hours: "number",
         link_color: "string",
+        bottom_offset: "number",
     },
 }));


### PR DESCRIPTION
## Summary
- Adds a new `bottom_offset` prop (number, default `20`) that controls the widget's vertical distance from the viewport bottom
- Affects trigger button, window wrapper, and chat window inner positioning for `bottom-left`/`bottom-right` positions
- Top positions (`top-left`, `top-right`) are unaffected

## Usage
```html
<punku-chat bottom_offset="40" host_url="..." flow_id="..."></punku-chat>
```

## Test plan
- [ ] `npm start` with no `bottom_offset` — should look identical to current behavior
- [ ] Add `bottom_offset="40"` — trigger and window should sit 20px higher than default
- [ ] Test with `chat_position="top-right"` — should be unaffected
- [x] `npm test` — all 242 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)